### PR TITLE
Give pdfs.json a unique name every build to avoid caching

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -29,7 +29,8 @@ const pluginLogPrefix = '[papersaurus] ';
 export async function generatePdfFiles(
   outDir: string,
   pluginOptions: PapersaurusPluginOptions,
-  { siteConfig, plugins }: Props) {
+  { siteConfig, plugins }: Props,
+  buildId: string) {
 
   console.log(`${pluginLogPrefix}Execute generatePdfFiles...`);
 
@@ -184,7 +185,8 @@ export async function generatePdfFiles(
 
   }
 
-  fs.writeFileSync(join(docusaurusBuildDir, 'pdfs.json'), JSON.stringify(linkToFile));
+  let pdfsJsonPath = join(docusaurusBuildDir, 'pdfs' + buildId + '.json');
+  fs.writeFileSync(pdfsJsonPath, JSON.stringify(linkToFile));
 
   browser.close();
   httpServer.close();

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export default function (
 ): Plugin<void> {
 
   let pluginOptions:PapersaurusPluginOptions = processOptions(options);
+  const buildId = Math.trunc(Date.now() / 1000).toString();
 
   return {
 
@@ -150,7 +151,7 @@ export default function (
           };
           
           $(window).on('load', function () {
-            fetch(getBaseUrl() + 'pdfs.json')
+            fetch(getBaseUrl() + 'pdfs' + ${buildId} + '.json')
               .then((response) => response.json())
               .then(function (json) {
                 pdfData = json;
@@ -166,7 +167,7 @@ export default function (
     async postBuild(props) {
       let forceBuild = process.env.BUILD_PDF || "";
       if ((pluginOptions.autoBuildPdfs && !forceBuild.startsWith("0")) || forceBuild.startsWith("1")) {
-        await generatePdfFiles(_context.outDir, pluginOptions, props);
+        await generatePdfFiles(_context.outDir, pluginOptions, props, buildId);
       }
     },
 


### PR DESCRIPTION
When adding versions or pages to docusaurus, the user wouldn't directly be able to download those as the pdfs.json got cached if they had visited the docs before. This avoids that issue in the same way as docusaurus itself does with all content files.